### PR TITLE
feat: Add themed icon support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
## This PR adds the Themed Icon feature introduced in [Android 13](https://www.android.com/android-13/#a13-your-phone-your-aesthetic)

### Examples:

- #### Normal icon for reference

  ####
  #### <img src="https://github.com/user-attachments/assets/7578903e-ef9a-4f71-8604-3bebfd3bbfe8" width="20%"/>

- #### Light Theme, Yellow Palette
  ####
  #### <img src="https://github.com/user-attachments/assets/0ea8d8a2-462d-4ee1-b3b6-1b62db03078a" width="20%"/>

- #### Dark Theme, Yellow Palette
  ####
  #### <img src="https://github.com/user-attachments/assets/1c02f2c9-69d8-4e90-836a-7307728e7e93" width="20%"/>