### PR TITLE
CI: Upload apk after a build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,3 +35,14 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle without running tests
       run: ./gradlew build --exclude-task test 
+
+    - name: Upload Release APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-release-unsigned.apk
+        path: app/build/outputs/apk/release/app-release-unsigned.apk
+    - name: Upload Debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: app-debug.apk
+        path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
Just a small quality of life change - allows you to download builds from the CI