### PR TITLE
Fix NullPointerException in TCPConnection caused by concurrent writes

### DIFF
--- a/app/src/main/java/com/github/umer0586/droidpad/data/connection/TCPConnection.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/data/connection/TCPConnection.kt
@@ -29,7 +29,6 @@ import io.ktor.network.sockets.TypeOfService
 import io.ktor.network.sockets.aSocket
 import io.ktor.network.sockets.openWriteChannel
 import io.ktor.utils.io.ByteWriteChannel
-import io.ktor.utils.io.awaitFreeSpace
 import io.ktor.utils.io.writeStringUtf8
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/github/umer0586/droidpad/data/connection/TCPConnection.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/data/connection/TCPConnection.kt
@@ -19,17 +19,23 @@
 
 package com.github.umer0586.droidpad.data.connection
 
+import android.util.Log
 import com.github.umer0586.droidpad.data.connectionconfig.TCPConfig
 import com.github.umer0586.droidpad.data.database.entities.ConnectionType
 import io.ktor.network.selector.SelectorManager
 import io.ktor.network.sockets.Socket
+import io.ktor.network.sockets.SocketOptions
+import io.ktor.network.sockets.TypeOfService
 import io.ktor.network.sockets.aSocket
 import io.ktor.network.sockets.openWriteChannel
 import io.ktor.utils.io.ByteWriteChannel
+import io.ktor.utils.io.awaitFreeSpace
 import io.ktor.utils.io.writeStringUtf8
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 
@@ -40,8 +46,13 @@ class TCPConnection(
 ) : Connection() {
 
     private var selectorManager: SelectorManager? = null
+    private val TAG: String = "TCPConnection"
     private var socket : Socket? = null
     private var writeChannel: ByteWriteChannel ? = null
+
+    // sendData Coroutine write lock
+    // Fixes a NullPointerExcept that occurs when using multiple joysticks at once
+    private val writeMutex = Mutex()
 
     override val connectionType: ConnectionType
         get() = ConnectionType.TCP
@@ -59,6 +70,12 @@ class TCPConnection(
                 withTimeout(tcpConfig.timeoutSecs*1000L) {
                     socket = aSocket(selectorManager)
                         .tcp()
+                        .configure {
+                            if (this is SocketOptions.TCPClientSocketOptions) {
+                                this.noDelay = false;
+                                this.typeOfService = TypeOfService.IPTOS_LOWDELAY
+                            }
+                        }
                         .connect(tcpConfig.host, tcpConfig.port)
                 }
 
@@ -79,12 +96,17 @@ class TCPConnection(
     }
 
     override suspend fun sendData(data: String) = withContext<Unit>(ioDispatcher){
+
         try {
-            writeChannel?.writeStringUtf8(data)
+            writeMutex.withLock {
+                writeChannel?.writeStringUtf8(data)
+            }
         } catch (e: Exception) {
+            Log.e(TAG, "sendData: $e")
             e.printStackTrace()
             notifyConnectionState(ConnectionState.TCP_ERROR)
         }
+
     }
 
     override suspend fun tearDown() = withContext(ioDispatcher) {


### PR DESCRIPTION
# PR description
This pull request adds a `Mutex` to the `TCPConnection` class to lock concurrent writes to the `ByteWriteChannel` and fix a `NullPointerException`.

# Bug description
This exception would occur when using multiple joysticks at the same time, which incurred many concurrent writes in the `sendData` coroutine and sometimes resulted in the following exception down the socket writing pipeline : 
```
5.341 17567-17604 TCPConnection           com.github.umer0586.droidpad         E  sendData: java.lang.NullPointerException
2025-06-21 18:57:45.342 17567-17605 System.err              com.github.umer0586.droidpad         W  java.lang.NullPointerException
2025-06-21 18:57:45.342 17567-17605 System.err              com.github.umer0586.droidpad         W  	at kotlinx.io.Buffer.write(Buffer.kt:460)
2025-06-21 18:57:45.342 17567-17605 System.err              com.github.umer0586.droidpad         W  	at kotlinx.io.Buffer.readAtMostTo(Buffer.kt:325)
2025-06-21 18:57:45.342 17567-17605 System.err              com.github.umer0586.droidpad         W  	at kotlinx.io.Buffer.transferFrom(Buffer.kt:494)
2025-06-21 18:57:45.343 17567-17605 System.err              com.github.umer0586.droidpad         W  	at io.ktor.utils.io.ByteChannel.flushWriteBuffer(ByteChannel.kt:107)
2025-06-21 18:57:45.343 17567-17605 System.err              com.github.umer0586.droidpad         W  	at io.ktor.utils.io.ByteChannel.flush(ByteChannel.kt:93)
2025-06-21 18:57:45.343 17567-17605 System.err              com.github.umer0586.droidpad         W  	at io.ktor.utils.io.ByteWriteChannelKt.flushIfNeeded(ByteWriteChannel.kt:61)
2025-06-21 18:57:45.343 17567-17605 System.err              com.github.umer0586.droidpad         W  	at io.ktor.utils.io.ByteWriteChannelOperationsKt.writeStringUtf8(ByteWriteChannelOperations.kt:97)
2025-06-21 18:57:45.343 17567-17605 System.err              com.github.umer0586.droidpad         W  	at com.github.umer0586.droidpad.data.connection.TCPConnection$sendData$2.invokeSuspend(TCPConnection.kt:103)
```