### PR TITLE
Angle snapping in control pad editor

### DIFF
--- a/app/src/androidTest/java/com/github/umer0586/droidpad/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/github/umer0586/droidpad/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package com.github.umer0586.droidpad
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -964,7 +964,8 @@ fun EditorAidsBottomSheetContent(
                     )
                 },
                 supportingContent = {
-                    Text("per ${360f / uiState.angleSnapDivision}°(360/${uiState.angleSnapDivision})")
+                    val angle = 360f / uiState.angleSnapDivision
+                    Text("per ${"%.2f".format(angle)}°(360/${uiState.angleSnapDivision})")
                 },
             )
 

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -941,7 +941,12 @@ fun EditorAidsBottomSheetContent(
         ListItem(
             modifier = Modifier.fillMaxWidth(0.7f),
             headlineContent = { Text(text = "Enable Angle Snap") },
-            supportingContent = { Text("Snap to specific angle automatically") },
+            supportingContent = {
+                Text(
+                    text = "Snap to specific angle automatically",
+                    style = MaterialTheme.typography.labelSmall
+                )
+            },
             trailingContent = {
                 Switch(
                     checked = uiState.useAngleSnap,

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Done
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -63,10 +62,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -74,7 +70,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
@@ -123,7 +118,6 @@ import com.github.umer0586.droidpad.ui.components.rotateBy
 import com.github.umer0586.droidpad.ui.theme.DroidPadTheme
 import com.github.umer0586.droidpad.ui.utils.LockScreenOrientation
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 
 
 // TODO: Add color picker for choosing background color of ControlPad
@@ -947,6 +941,7 @@ fun EditorAidsBottomSheetContent(
         ListItem(
             modifier = Modifier.fillMaxWidth(0.7f),
             headlineContent = { Text(text = "Enable Angle Snap") },
+            supportingContent = { Text("Snap to specific angle automatically") },
             trailingContent = {
                 Switch(
                     checked = uiState.useAngleSnap,
@@ -968,37 +963,7 @@ fun EditorAidsBottomSheetContent(
                         }
                     )
                 },
-                overlineContent = {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-
-                        val tooltipState = rememberTooltipState()
-                        val scope = rememberCoroutineScope()
-
-                        Text(text = "Angle Snap")
-
-                        Spacer(modifier = Modifier.width(8.dp))
-
-                        TooltipBox(
-                            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
-                            tooltip = {
-                                Text(text = "Snaps to specific angles automaticly")
-                            },
-                            state = tooltipState,
-                        ) {
-                            Icon(
-                                modifier = Modifier.clickable {
-                                    scope.launch {
-                                        tooltipState.show()
-                                    }
-                                },
-                                imageVector = Icons.Filled.Info,
-                                contentDescription = null,
-                            )
-                        }
-                    }
-                },
                 supportingContent = {
-                    //Text("Ratio of handle radius to joystick radius")
                     Text("per ${360f / uiState.angleSnapDivision}°(360/${uiState.angleSnapDivision})")
                 },
             )

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -120,7 +120,6 @@ import com.github.umer0586.droidpad.ui.components.ControlPadSwitch
 import com.github.umer0586.droidpad.ui.components.LEDSTATE
 import com.github.umer0586.droidpad.ui.components.propertieseditor.ItemPropertiesEditorSheet
 import com.github.umer0586.droidpad.ui.components.rotateBy
-import com.github.umer0586.droidpad.ui.screens.preferencescreen.PreferenceScreenEvent
 import com.github.umer0586.droidpad.ui.theme.DroidPadTheme
 import com.github.umer0586.droidpad.ui.utils.LockScreenOrientation
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -269,7 +270,7 @@ fun ControlPadBuilderScreenContent(
                         },
                         content = {
                             Icon(
-                                imageVector = Icons.Filled.Build,
+                                imageVector = Icons.Filled.Settings,
                                 contentDescription = "AidsIcon"
                             )
                         }

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -176,6 +176,8 @@ fun ControlPadBuilderScreenContent(
 
 ) {
 
+    var showEditorAids by remember { mutableStateOf(false) }
+
     Scaffold(
         bottomBar = {
 
@@ -265,7 +267,7 @@ fun ControlPadBuilderScreenContent(
                     )
                     IconButton(
                         onClick = {
-                            onUiEvent(ControlPadBuilderScreenEvent.OnEditorAidsClick)
+                            showEditorAids = true
                         },
                         content = {
                             Icon(
@@ -694,10 +696,10 @@ fun ControlPadBuilderScreenContent(
                     )
                 }
             }
-            if (uiState.showEditorAids) {
+            if (showEditorAids) {
                 ModalBottomSheet(
                     sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-                    onDismissRequest = { onUiEvent(ControlPadBuilderScreenEvent.OnEditorAidsDismissRequest) }
+                    onDismissRequest = { showEditorAids = false }
                 ) {
                     EditorAidsBottomSheetContent(uiState = uiState, onUiEvent = onUiEvent)
                 }

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -965,7 +965,7 @@ fun EditorAidsBottomSheetContent(
                 },
                 supportingContent = {
                     val angle = 360f / uiState.angleSnapDivision
-                    Text("per ${"%.2f".format(angle)}°(360/${uiState.angleSnapDivision})")
+                    Text("Snap per ${"%.2f".format(angle)}°(360/${uiState.angleSnapDivision})")
                 },
             )
 

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -46,7 +46,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreen.kt
@@ -23,6 +23,7 @@ import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.util.Log
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.TransformableState
@@ -45,19 +46,27 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -65,6 +74,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
@@ -110,9 +120,11 @@ import com.github.umer0586.droidpad.ui.components.ControlPadSwitch
 import com.github.umer0586.droidpad.ui.components.LEDSTATE
 import com.github.umer0586.droidpad.ui.components.propertieseditor.ItemPropertiesEditorSheet
 import com.github.umer0586.droidpad.ui.components.rotateBy
+import com.github.umer0586.droidpad.ui.screens.preferencescreen.PreferenceScreenEvent
 import com.github.umer0586.droidpad.ui.theme.DroidPadTheme
 import com.github.umer0586.droidpad.ui.utils.LockScreenOrientation
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 
 // TODO: Add color picker for choosing background color of ControlPad
@@ -128,14 +140,14 @@ fun ControlPadBuilderScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    LaunchedEffect(Unit){
-        Log.d("ControlPadBuilderScreen","LaunchedEffect(Unit) : ${controlPad.id}")
+    LaunchedEffect(Unit) {
+        Log.d("ControlPadBuilderScreen", "LaunchedEffect(Unit) : ${controlPad.id}")
         if (!tempOpen)
             viewModel.loadControlPadItemsFor(controlPad)
     }
 
     LockScreenOrientation(
-        orientation = when(controlPad.orientation){
+        orientation = when (controlPad.orientation) {
             Orientation.PORTRAIT -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
             Orientation.LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
         }
@@ -148,11 +160,11 @@ fun ControlPadBuilderScreen(
         onUiEvent = { event ->
             viewModel.onEvent(event)
 
-            if(event is ControlPadBuilderScreenEvent.OnSaveClick)
+            if (event is ControlPadBuilderScreenEvent.OnSaveClick)
                 onSaveClick?.invoke()
-            else if(event is ControlPadBuilderScreenEvent.OnBackPress)
+            else if (event is ControlPadBuilderScreenEvent.OnBackPress)
                 onBackPress?.invoke()
-            else if(event is ControlPadBuilderScreenEvent.OnTempOpenCompleted)
+            else if (event is ControlPadBuilderScreenEvent.OnTempOpenCompleted)
                 onTempOpenCompleted?.invoke(externalData)
 
         }
@@ -174,107 +186,118 @@ fun ControlPadBuilderScreenContent(
     Scaffold(
         bottomBar = {
 
-                Box(
-                    modifier = Modifier
-                        .navigationBarsPadding()
-                        .fillMaxWidth()
-                        .height(bottomBarHeight)
-                        .background(MaterialTheme.colorScheme.primary),
-                    contentAlignment = Alignment.Center
-                ) {
+            Box(
+                modifier = Modifier
+                    .navigationBarsPadding()
+                    .fillMaxWidth()
+                    .height(bottomBarHeight)
+                    .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center
+            ) {
 
-                    var showModificationAlert by remember { mutableStateOf(false) }
+                var showModificationAlert by remember { mutableStateOf(false) }
 
-                    // When back button on device is pressed
-                    BackHandler {
-                        if(uiState.isModified){
-                            showModificationAlert = true
-                            return@BackHandler
-                        }
-                        onUiEvent(ControlPadBuilderScreenEvent.OnBackPress)
+                // When back button on device is pressed
+                BackHandler {
+                    if (uiState.isModified) {
+                        showModificationAlert = true
+                        return@BackHandler
                     }
+                    onUiEvent(ControlPadBuilderScreenEvent.OnBackPress)
+                }
 
-                    if(showModificationAlert){
-                        AlertDialog(
-                            onDismissRequest = { showModificationAlert = false },
-                            title = { Text(text = "Unsaved Changes") },
-                            text = { Text(text = "Interface has been modified") },
-                            confirmButton = {
-                                TextButton(
-                                    onClick = {
-                                        showModificationAlert = false
-                                        onUiEvent(ControlPadBuilderScreenEvent.OnBackPress)
-                                    }
-                                ) { Text("Discard Changes")}
+                if (showModificationAlert) {
+                    AlertDialog(
+                        onDismissRequest = { showModificationAlert = false },
+                        title = { Text(text = "Unsaved Changes") },
+                        text = { Text(text = "Interface has been modified") },
+                        confirmButton = {
+                            TextButton(
+                                onClick = {
+                                    showModificationAlert = false
+                                    onUiEvent(ControlPadBuilderScreenEvent.OnBackPress)
+                                }
+                            ) { Text("Discard Changes") }
+                        },
+                        dismissButton = {
+                            TextButton(
+                                onClick = {
+                                    showModificationAlert = false
+                                    onUiEvent(ControlPadBuilderScreenEvent.OnSaveClick)
+                                }
+                            ) { Text("Save Changes") }
+                        }
+                    )
+                }
+
+                IconButton(
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    onClick = {
+                        onUiEvent(ControlPadBuilderScreenEvent.OnAddItemClick)
+                    },
+                    content = {
+                        Icon(
+                            modifier = Modifier.clickable {
+
+                                if (uiState.isModified) {
+                                    showModificationAlert = true
+                                    return@clickable
+                                }
+
+                                onUiEvent(ControlPadBuilderScreenEvent.OnBackPress)
                             },
-                            dismissButton = {
-                                TextButton(
-                                    onClick = {
-                                        showModificationAlert = false
-                                        onUiEvent(ControlPadBuilderScreenEvent.OnSaveClick)
-                                    }
-                                ) { Text("Save Changes")}
-                            }
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "AddIcon",
+                            tint = MaterialTheme.colorScheme.onPrimary
                         )
                     }
+                )
+
+                Row(
+                    Modifier
+                        .clip(shape = RoundedCornerShape(50.dp))
+                        .background(MaterialTheme.colorScheme.onPrimary),
+                ) {
 
                     IconButton(
-                        modifier = Modifier.align(Alignment.CenterStart),
                         onClick = {
                             onUiEvent(ControlPadBuilderScreenEvent.OnAddItemClick)
                         },
                         content = {
                             Icon(
-                                modifier = Modifier.clickable {
-
-                                    if(uiState.isModified){
-                                        showModificationAlert = true
-                                        return@clickable
-                                    }
-
-                                    onUiEvent(ControlPadBuilderScreenEvent.OnBackPress)
-                                },
-                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                                contentDescription = "AddIcon",
-                                tint = MaterialTheme.colorScheme.onPrimary
+                                imageVector = Icons.Filled.Add,
+                                contentDescription = "AddIcon"
+                            )
+                        }
+                    )
+                    IconButton(
+                        onClick = {
+                            onUiEvent(ControlPadBuilderScreenEvent.OnEditorAidsClick)
+                        },
+                        content = {
+                            Icon(
+                                imageVector = Icons.Filled.Build,
+                                contentDescription = "AidsIcon"
+                            )
+                        }
+                    )
+                    IconButton(
+                        onClick = {
+                            onUiEvent(ControlPadBuilderScreenEvent.OnSaveClick)
+                        },
+                        content = {
+                            Icon(
+                                imageVector = Icons.Filled.Done,
+                                contentDescription = "SaveIcon"
                             )
                         }
                     )
 
-                    Row(
-                        Modifier
-                            .clip(shape = RoundedCornerShape(50.dp))
-                            .background(MaterialTheme.colorScheme.onPrimary),
-                    ) {
-
-                        IconButton(
-                            onClick = {
-                                onUiEvent(ControlPadBuilderScreenEvent.OnAddItemClick)
-                            },
-                            content = {
-                                Icon(
-                                    imageVector = Icons.Filled.Add,
-                                    contentDescription = "AddIcon"
-                                )
-                            }
-                        )
-                        IconButton(
-                            onClick = {
-                                onUiEvent(ControlPadBuilderScreenEvent.OnSaveClick)
-                            },
-                            content = {
-                                Icon(
-                                    imageVector = Icons.Filled.Done,
-                                    contentDescription = "SaveIcon"
-                                )
-                            }
-                        )
-
-                    }
                 }
+            }
 
         }
-    ) { innerPadding->
+    ) { innerPadding ->
         BoxWithConstraints(
             Modifier
                 .fillMaxSize()
@@ -299,13 +322,13 @@ fun ControlPadBuilderScreenContent(
                     )
                 )
 
-                if(tempOpen) {
+                if (tempOpen) {
                     delay(5000)
                     onUiEvent(ControlPadBuilderScreenEvent.OnTempOpenCompleted)
                 }
             }
 
-            if(tempOpen){
+            if (tempOpen) {
                 Column(
                     modifier = Modifier.align(Alignment.Center),
                     horizontalAlignment = Alignment.CenterHorizontally
@@ -319,7 +342,7 @@ fun ControlPadBuilderScreenContent(
             }
 
 
-            uiState.controlPadItems.forEach{controlPadItem ->
+            uiState.controlPadItems.forEach { controlPadItem ->
 
                 if (controlPadItem.itemType == ItemType.SWITCH && uiState.transformableStatesMap[controlPadItem.id] != null) {
 
@@ -348,9 +371,7 @@ fun ControlPadBuilderScreenContent(
                         }
 
                     )
-                }
-
-                else if (controlPadItem.itemType == ItemType.SLIDER && uiState.transformableStatesMap[controlPadItem.id] != null) {
+                } else if (controlPadItem.itemType == ItemType.SLIDER && uiState.transformableStatesMap[controlPadItem.id] != null) {
                     val properties = SliderProperties.fromJson(controlPadItem.properties)
                     ControlPadSlider(
                         offset = controlPadItem.offset,
@@ -359,7 +380,7 @@ fun ControlPadBuilderScreenContent(
                         transformableState = uiState.transformableStatesMap[controlPadItem.id],
                         properties = properties,
                         enabled = false,
-                        value = (properties.minValue + properties.maxValue)/2,
+                        value = (properties.minValue + properties.maxValue) / 2,
                         onDeleteClick = {
                             onUiEvent(
                                 ControlPadBuilderScreenEvent.OnDeleteItemClick(
@@ -379,9 +400,7 @@ fun ControlPadBuilderScreenContent(
 
 
                     )
-                }
-
-                else if (controlPadItem.itemType == ItemType.STEP_SLIDER && uiState.transformableStatesMap[controlPadItem.id] != null) {
+                } else if (controlPadItem.itemType == ItemType.STEP_SLIDER && uiState.transformableStatesMap[controlPadItem.id] != null) {
                     val properties = StepSliderProperties.fromJson(controlPadItem.properties)
                     ControlPadStepSlider(
                         offset = controlPadItem.offset,
@@ -390,7 +409,7 @@ fun ControlPadBuilderScreenContent(
                         transformableState = uiState.transformableStatesMap[controlPadItem.id],
                         properties = properties,
                         enabled = false,
-                        value = (properties.minValue + properties.maxValue)/2,
+                        value = (properties.minValue + properties.maxValue) / 2,
                         onDeleteClick = {
                             onUiEvent(
                                 ControlPadBuilderScreenEvent.OnDeleteItemClick(
@@ -408,9 +427,7 @@ fun ControlPadBuilderScreenContent(
                             )
                         }
                     )
-                }
-
-                else if(controlPadItem.itemType == ItemType.LABEL && uiState.transformableStatesMap[controlPadItem.id] != null){
+                } else if (controlPadItem.itemType == ItemType.LABEL && uiState.transformableStatesMap[controlPadItem.id] != null) {
                     ControlPadLabel(
                         offset = controlPadItem.offset,
                         rotation = controlPadItem.rotation,
@@ -434,9 +451,7 @@ fun ControlPadBuilderScreenContent(
                             )
                         }
                     )
-                }
-
-                else if(controlPadItem.itemType == ItemType.BUTTON && uiState.transformableStatesMap[controlPadItem.id] != null){
+                } else if (controlPadItem.itemType == ItemType.BUTTON && uiState.transformableStatesMap[controlPadItem.id] != null) {
 
                     ControlPadButton(
                         offset = controlPadItem.offset,
@@ -462,9 +477,7 @@ fun ControlPadBuilderScreenContent(
                             )
                         }
                     )
-                }
-
-                else if(controlPadItem.itemType == ItemType.DPAD && uiState.transformableStatesMap[controlPadItem.id] != null){
+                } else if (controlPadItem.itemType == ItemType.DPAD && uiState.transformableStatesMap[controlPadItem.id] != null) {
 
                     ControlPadDpad(
                         offset = controlPadItem.offset,
@@ -490,9 +503,7 @@ fun ControlPadBuilderScreenContent(
                             )
                         }
                     )
-                }
-
-                else if(controlPadItem.itemType == ItemType.JOYSTICK && uiState.transformableStatesMap[controlPadItem.id] != null){
+                } else if (controlPadItem.itemType == ItemType.JOYSTICK && uiState.transformableStatesMap[controlPadItem.id] != null) {
 
                     ControlPadJoyStick(
                         offset = controlPadItem.offset,
@@ -518,8 +529,7 @@ fun ControlPadBuilderScreenContent(
                             )
                         }
                     )
-                }
-                else if(controlPadItem.itemType == ItemType.STEERING_WHEEL && uiState.transformableStatesMap[controlPadItem.id] != null){
+                } else if (controlPadItem.itemType == ItemType.STEERING_WHEEL && uiState.transformableStatesMap[controlPadItem.id] != null) {
                     ControlPadSteeringWheel(
                         offset = controlPadItem.offset,
                         rotation = controlPadItem.rotation,
@@ -544,9 +554,7 @@ fun ControlPadBuilderScreenContent(
                             )
                         }
                     )
-                }
-
-                else if(controlPadItem.itemType == ItemType.LED && uiState.transformableStatesMap[controlPadItem.id] != null){
+                } else if (controlPadItem.itemType == ItemType.LED && uiState.transformableStatesMap[controlPadItem.id] != null) {
 
                     ControlPadLED(
                         offset = controlPadItem.offset,
@@ -573,9 +581,7 @@ fun ControlPadBuilderScreenContent(
                         }
 
                     )
-                }
-
-                else if(controlPadItem.itemType == ItemType.GAUGE && uiState.transformableStatesMap[controlPadItem.id] != null){
+                } else if (controlPadItem.itemType == ItemType.GAUGE && uiState.transformableStatesMap[controlPadItem.id] != null) {
 
                     ControlPadGauge(
                         modifier = Modifier.size(250.dp),
@@ -584,7 +590,8 @@ fun ControlPadBuilderScreenContent(
                         rotation = controlPadItem.rotation,
                         scale = controlPadItem.scale,
                         transformableState = uiState.transformableStatesMap[controlPadItem.id],
-                        properties = GaugeProperties.fromJson(controlPadItem.properties).copy(minValue = 0f, maxValue = 20f),
+                        properties = GaugeProperties.fromJson(controlPadItem.properties)
+                            .copy(minValue = 0f, maxValue = 20f),
                         onDeleteClick = {
                             onUiEvent(
                                 ControlPadBuilderScreenEvent.OnDeleteItemClick(
@@ -605,8 +612,6 @@ fun ControlPadBuilderScreenContent(
                 }
 
 
-
-
             }
 
             val primary = MaterialTheme.colorScheme.primary
@@ -621,39 +626,47 @@ fun ControlPadBuilderScreenContent(
                     ItemSelectionBottomSheetContent(
                         onItemClick = { itemType ->
 
-                            val properties = when(itemType){
+                            val properties = when (itemType) {
                                 ItemType.LABEL -> LabelProperties().toJson()
                                 ItemType.BUTTON -> ButtonProperties(
                                     buttonColor = primary.value,
                                     textColor = onPrimary.value,
                                     iconColor = onPrimary.value,
                                 ).toJson()
+
                                 ItemType.SWITCH -> SwitchProperties(
                                     trackColor = primary.value,
                                     thumbColor = onPrimary.value,
                                 ).toJson()
+
                                 ItemType.SLIDER -> SliderProperties(
                                     trackColor = primary.value,
                                     thumbColor = primary.value,
                                 ).toJson()
+
                                 ItemType.STEP_SLIDER -> StepSliderProperties(
                                     trackColor = primary.value,
                                     thumbColor = primary.value,
                                 ).toJson()
+
                                 ItemType.DPAD -> DpadProperties(
                                     backgroundColor = primary.value,
                                     buttonColor = onPrimary.value,
                                 ).toJson()
+
                                 ItemType.JOYSTICK -> JoyStickProperties(
                                     backgroundColor = primary.value,
                                     handleColor = onPrimary.value,
                                 ).toJson()
+
                                 ItemType.STEERING_WHEEL -> SteeringWheelProperties(
                                     color = primary.value
                                 ).toJson()
+
                                 ItemType.LED -> LEDProperties(
                                     color = primary.value
                                 ).toJson()
+
                                 ItemType.GAUGE -> GaugeProperties(
                                     color = primary.value
                                 ).toJson()
@@ -664,9 +677,8 @@ fun ControlPadBuilderScreenContent(
                                     itemType = itemType,
                                     controlPad = controlPad,
                                     properties = properties
-                                    )
+                                )
                             )
-
 
 
                         }
@@ -689,7 +701,14 @@ fun ControlPadBuilderScreenContent(
                     )
                 }
             }
-
+            if (uiState.showEditorAids) {
+                ModalBottomSheet(
+                    sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+                    onDismissRequest = { onUiEvent(ControlPadBuilderScreenEvent.OnEditorAidsDismissRequest) }
+                ) {
+                    EditorAidsBottomSheetContent(uiState = uiState, onUiEvent = onUiEvent)
+                }
+            }
         }
     }
 
@@ -717,7 +736,7 @@ private fun ItemSelectionBottomSheetContent(
                     .padding(20.dp),
                 horizontalArrangement = Arrangement.SpaceEvenly,
                 verticalAlignment = Alignment.CenterVertically
-            ){
+            ) {
                 Icon(
                     modifier = Modifier.size(25.dp),
                     painter = painterResource(
@@ -760,7 +779,7 @@ private fun ItemSelectionBottomSheetContentPreview() {
 }
 
 
-@Preview(showBackground = true,uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun ControlPadBuilderScreenContentInteractiveXPreview() {
     val uiState = remember {
@@ -780,7 +799,7 @@ fun ControlPadBuilderScreenContentInteractiveXPreview() {
         orientation = Orientation.LANDSCAPE,
     )
 
-    val controlPadItems = remember{
+    val controlPadItems = remember {
         mutableStateListOf(
             ControlPadItem(
                 id = 1000,
@@ -834,20 +853,22 @@ fun ControlPadBuilderScreenContentInteractiveXPreview() {
                         uiState.value.transformableStatesMap[newItem.id] =
                             TransformableState { zoomChange, offsetChange, rotationChange ->
 
-                                val index = uiState.value.controlPadItems.indexOfFirst { it.id == newItem.id }
+                                val index =
+                                    uiState.value.controlPadItems.indexOfFirst { it.id == newItem.id }
 
                                 val controlPadItem = uiState.value.controlPadItems[index]
 
                                 val newScale = controlPadItem.scale * zoomChange
                                 val newRotation = controlPadItem.rotation + rotationChange
-                                val newOffset = controlPadItem.offset + offsetChange.rotateBy(newRotation) * newScale
+                                val newOffset =
+                                    controlPadItem.offset + offsetChange.rotateBy(newRotation) * newScale
 
                                 uiState.value.controlPadItems[index] =
                                     controlPadItem.copy(
                                         offsetX = newOffset.x,
                                         offsetY = newOffset.y,
                                         rotation = newRotation,
-                                        scale = newScale.coerceIn(minScale,maxScale)
+                                        scale = newScale.coerceIn(minScale, maxScale)
                                     )
 
                             }
@@ -871,7 +892,8 @@ fun ControlPadBuilderScreenContentInteractiveXPreview() {
                     is ControlPadBuilderScreenEvent.OnItemEditSubmit -> {
                         uiState.value = uiState.value.copy(showItemEditor = false)
 
-                        val index = uiState.value.controlPadItems.indexOfFirst { it.id == event.controlPadItem.id }
+                        val index =
+                            uiState.value.controlPadItems.indexOfFirst { it.id == event.controlPadItem.id }
                         val controlPadItem = uiState.value.controlPadItems[index]
                         uiState.value.controlPadItems[index] = controlPadItem.copy(
                             itemIdentifier = event.controlPadItem.itemIdentifier,
@@ -882,6 +904,7 @@ fun ControlPadBuilderScreenContentInteractiveXPreview() {
                         //database operation
 
                     }
+
                     else -> TODO("Not Yet Implemented")
                 }
             }
@@ -889,5 +912,99 @@ fun ControlPadBuilderScreenContentInteractiveXPreview() {
         )
     }
 
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun EditorAidsBottomSheetContentPreview() {
+    val uiState = remember {
+        mutableStateOf(
+            ControlPadBuilderScreenState(
+                controlPadItems = mutableStateListOf(),
+                transformableStatesMap = SnapshotStateMap(),
+                isModified = true
+            )
+        )
+    }
+    DroidPadTheme {
+        Surface {
+            EditorAidsBottomSheetContent(uiState = uiState.value, onUiEvent = {})
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditorAidsBottomSheetContent(
+    modifier: Modifier = Modifier,
+    uiState: ControlPadBuilderScreenState,
+    onUiEvent: (ControlPadBuilderScreenEvent) -> Unit)
+{
+
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        ListItem(
+            modifier = Modifier.fillMaxWidth(0.7f),
+            headlineContent = { Text(text = "Enable Angle Snap") },
+            trailingContent = {
+                Switch(
+                    checked = uiState.useAngleSnap,
+                    onCheckedChange = {
+                        onUiEvent(ControlPadBuilderScreenEvent.OnUseAngleSnapChange)
+                    }
+                )
+            }
+        )
+        AnimatedVisibility(uiState.useAngleSnap) {
+            ListItem(
+                modifier = Modifier.fillMaxWidth(0.7f),
+                headlineContent = {
+                    Slider(
+                        valueRange = 4f..36f,
+                        value = uiState.angleSnapDivision.toFloat(),
+                        onValueChange = {newValue ->
+                            onUiEvent(ControlPadBuilderScreenEvent.OnAngleSnapChange(newValue))
+                        }
+                    )
+                },
+                overlineContent = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+
+                        val tooltipState = rememberTooltipState()
+                        val scope = rememberCoroutineScope()
+
+                        Text(text = "Angle Snap")
+
+                        Spacer(modifier = Modifier.width(8.dp))
+
+                        TooltipBox(
+                            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                            tooltip = {
+                                Text(text = "Snaps to specific angles automaticly")
+                            },
+                            state = tooltipState,
+                        ) {
+                            Icon(
+                                modifier = Modifier.clickable {
+                                    scope.launch {
+                                        tooltipState.show()
+                                    }
+                                },
+                                imageVector = Icons.Filled.Info,
+                                contentDescription = null,
+                            )
+                        }
+                    }
+                },
+                supportingContent = {
+                    //Text("Ratio of handle radius to joystick radius")
+                    Text("per ${360f / uiState.angleSnapDivision}°(360/${uiState.angleSnapDivision})")
+                },
+            )
+
+        }
+    }
 }
 

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
@@ -52,7 +52,6 @@ data class ControlPadBuilderScreenState(
     val itemToBeEdited: ControlPadItem? = null,
     val transformableStatesMap: SnapshotStateMap<Long, TransformableState> = SnapshotStateMap(),
     val isModified: Boolean = false,
-    val showEditorAids: Boolean = false,
     val useAngleSnap: Boolean = false,
     val angleSnapDivision:Int = 36,
     )
@@ -69,8 +68,6 @@ sealed interface ControlPadBuilderScreenEvent {
     data object OnBackPress: ControlPadBuilderScreenEvent
     data class OnResolutionReported(val controlPad: ControlPad, val builderScreenResolution: Resolution, val tempOpen : Boolean = false) : ControlPadBuilderScreenEvent
     data object OnTempOpenCompleted : ControlPadBuilderScreenEvent
-    data object OnEditorAidsClick: ControlPadBuilderScreenEvent
-    data object OnEditorAidsDismissRequest: ControlPadBuilderScreenEvent
     data object OnUseAngleSnapChange: ControlPadBuilderScreenEvent
     data class OnAngleSnapChange(val newValue:Float) : ControlPadBuilderScreenEvent
 
@@ -303,16 +300,6 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
 
             }
 
-            is ControlPadBuilderScreenEvent.OnEditorAidsClick -> {
-                _uiState.update {
-                    it.copy(showEditorAids = true)
-                }
-            }
-            is ControlPadBuilderScreenEvent.OnEditorAidsDismissRequest -> {
-                _uiState.update {
-                    it.copy(showEditorAids = false)
-                }
-            }
             is ControlPadBuilderScreenEvent.OnUseAngleSnapChange ->{
                 _uiState.update {
                     it.copy(useAngleSnap = !it.useAngleSnap)

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
@@ -110,7 +110,6 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
         _uiState.update {
             it.copy(isModified = false)
         }
-        var temporalRotation: Float
         viewModelScope.launch {
             Log.d(tag, "loadControlPadItemsFor: ")
             controlPadRepository.getControlPadItemsOf(controlPad).also{ items ->

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.roundToInt
 
 
 data class ControlPadBuilderScreenState(
@@ -50,8 +51,11 @@ data class ControlPadBuilderScreenState(
     val showItemEditor: Boolean = false,
     val itemToBeEdited: ControlPadItem? = null,
     val transformableStatesMap: SnapshotStateMap<Long, TransformableState> = SnapshotStateMap(),
-    val isModified: Boolean = false
-)
+    val isModified: Boolean = false,
+    val showEditorAids: Boolean = false,
+    val useAngleSnap: Boolean = false,
+    val angleSnapDivision:Int = 36,
+    )
 
 sealed interface ControlPadBuilderScreenEvent {
     data object OnAddItemClick : ControlPadBuilderScreenEvent
@@ -65,6 +69,10 @@ sealed interface ControlPadBuilderScreenEvent {
     data object OnBackPress: ControlPadBuilderScreenEvent
     data class OnResolutionReported(val controlPad: ControlPad, val builderScreenResolution: Resolution, val tempOpen : Boolean = false) : ControlPadBuilderScreenEvent
     data object OnTempOpenCompleted : ControlPadBuilderScreenEvent
+    data object OnEditorAidsClick: ControlPadBuilderScreenEvent
+    data object OnEditorAidsDismissRequest: ControlPadBuilderScreenEvent
+    data object OnUseAngleSnapChange: ControlPadBuilderScreenEvent
+    data class OnAngleSnapChange(val newValue:Float) : ControlPadBuilderScreenEvent
 
 }
 
@@ -91,16 +99,24 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
         Log.d(tag,"onCleared() ${hashCode()}")
     }
 
+    fun snappedRotation(input: Float):Float{
+        return input.div(360).times(_uiState.value.angleSnapDivision)// Scale the input into [-angleSnapDivision,angleSnapDivision]
+            .roundToInt()// Snap!
+            .times(360).toFloat().div(_uiState.value.angleSnapDivision)// Scale back to normal and convert
+    }
     fun loadControlPadItemsFor(controlPad: ControlPad){
         _uiState.update {
             it.copy(isModified = false)
         }
+        var temporalRotation: Float
         viewModelScope.launch {
             Log.d(tag, "loadControlPadItemsFor: ")
             controlPadRepository.getControlPadItemsOf(controlPad).also{ items ->
                 Log.d(tag, items.toString())
                 _uiState.value.controlPadItems.clear()
                 items.forEach { item ->
+                    var temporalRotation: Float =item.rotation// I have little understanding on kotlin, thanks closure isolation
+
                     uiState.value.controlPadItems.add(item)
                     uiState.value.transformableStatesMap[item.id] =
                         TransformableState { zoomChange, offsetChange, rotationChange ->
@@ -110,7 +126,8 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
                             val controlPadItem = uiState.value.controlPadItems[index]
 
                             val newScale = controlPadItem.scale * zoomChange
-                            val newRotation = controlPadItem.rotation + rotationChange
+                            val newRotation = temporalRotation + rotationChange
+                            temporalRotation = newRotation
                             val newOffset = controlPadItem.offset + offsetChange.rotateBy(newRotation) * newScale
 
                             uiState.value.controlPadItems[index] =
@@ -118,7 +135,8 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
                                     offsetX = newOffset.x,
                                     offsetY = newOffset.y,
                                     // Joystick and steering wheel should not be rotatable
-                                    rotation = if(controlPadItem.itemType == ItemType.JOYSTICK || controlPadItem.itemType == ItemType.STEERING_WHEEL) 0f else newRotation,
+                                    rotation = if(controlPadItem.itemType == ItemType.JOYSTICK || controlPadItem.itemType == ItemType.STEERING_WHEEL) 0f
+                                    else if (_uiState.value.useAngleSnap) snappedRotation(newRotation) else newRotation,
                                     scale = newScale.coerceIn(minScale,maxScale)
                                 )
 
@@ -198,21 +216,20 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
                     properties = event.properties
                 )
                 viewModelScope.launch {
+                    var temporalRotation: Float =newItem.rotation
                     controlPadItemRepository.save(newItem).also { newId ->
                         controlPadItemRepository.getById(newId).also { newItem ->
 
                             uiState.value.controlPadItems.add(newItem!!)
 
-
                             uiState.value.transformableStatesMap[newItem.id] =
                                 TransformableState { zoomChange, offsetChange, rotationChange ->
-
                                     val index = uiState.value.controlPadItems.indexOfFirst { it.id == newItem.id }
-
                                     val controlPadItem = uiState.value.controlPadItems[index]
 
                                     val newScale = controlPadItem.scale * zoomChange
-                                    val newRotation = controlPadItem.rotation + rotationChange
+                                    val newRotation = temporalRotation + rotationChange
+                                    temporalRotation = newRotation
                                     val newOffset = controlPadItem.offset + offsetChange.rotateBy(newRotation) * newScale
 
                                     uiState.value.controlPadItems[index] =
@@ -220,7 +237,8 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
                                             offsetX = newOffset.x,
                                             offsetY = newOffset.y,
                                             // Joystick and steering wheel should not be rotatable
-                                            rotation = if(controlPadItem.itemType == ItemType.JOYSTICK || controlPadItem.itemType == ItemType.STEERING_WHEEL) 0f else newRotation,
+                                            rotation = if(controlPadItem.itemType == ItemType.JOYSTICK || controlPadItem.itemType == ItemType.STEERING_WHEEL) 0f
+                                                    else if (_uiState.value.useAngleSnap) snappedRotation(newRotation) else newRotation,
                                             scale = newScale.coerceIn(minScale,maxScale)
                                         )
 
@@ -259,6 +277,28 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
                 )
 
             }
+
+            is ControlPadBuilderScreenEvent.OnEditorAidsClick -> {
+                _uiState.update {
+                    it.copy(showEditorAids = true)
+                }
+            }
+            is ControlPadBuilderScreenEvent.OnEditorAidsDismissRequest -> {
+                _uiState.update {
+                    it.copy(showEditorAids = false)
+                }
+            }
+            is ControlPadBuilderScreenEvent.OnUseAngleSnapChange ->{
+                _uiState.update {
+                    it.copy(useAngleSnap = !it.useAngleSnap)
+                }
+            }
+            is ControlPadBuilderScreenEvent.OnAngleSnapChange -> {
+                _uiState.update {
+                    it.copy(angleSnapDivision = event.newValue.toInt())
+                }
+            }
+
 
             ControlPadBuilderScreenEvent.OnBackPress -> {}
             ControlPadBuilderScreenEvent.OnTempOpenCompleted -> {}

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
@@ -99,7 +99,7 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
         Log.d(tag,"onCleared() ${hashCode()}")
     }
 
-    fun snappedRotation(input: Float):Float{
+    private fun snappedRotation(input: Float):Float{
         return input.div(360).times(_uiState.value.angleSnapDivision)// Scale the input into [-angleSnapDivision,angleSnapDivision]
             .roundToInt()// Snap!
             .times(360).toFloat().div(_uiState.value.angleSnapDivision)// Scale back to normal and convert

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
@@ -99,10 +99,12 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
         Log.d(tag,"onCleared() ${hashCode()}")
     }
 
-    private fun snappedRotation(input: Float):Float{
-        return input.div(360).times(_uiState.value.angleSnapDivision)// Scale the input into [-angleSnapDivision,angleSnapDivision]
+    private fun snappedRotation(input: Float): Float {
+        return input.div(360)
+            .times(_uiState.value.angleSnapDivision)// Scale the input into [-angleSnapDivision,angleSnapDivision]
             .roundToInt()// Snap!
-            .times(360).toFloat().div(_uiState.value.angleSnapDivision)// Scale back to normal and convert
+            .times(360).toFloat()
+            .div(_uiState.value.angleSnapDivision)// Scale back to normal and convert
     }
     fun loadControlPadItemsFor(controlPad: ControlPad){
         _uiState.update {

--- a/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
+++ b/app/src/main/java/com/github/umer0586/droidpad/ui/screens/controlpadbuilderscreen/ControlPadBuilderScreenViewModel.kt
@@ -126,17 +126,29 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
                             val controlPadItem = uiState.value.controlPadItems[index]
 
                             val newScale = controlPadItem.scale * zoomChange
-                            val newRotation = temporalRotation + rotationChange
+
+                            val newRotation = if(controlPadItem.itemType == ItemType.JOYSTICK || controlPadItem.itemType == ItemType.STEERING_WHEEL) 0f
+                                else if (_uiState.value.useAngleSnap){ temporalRotation + rotationChange }
+                                else{ controlPadItem.rotation + rotationChange }
+
                             temporalRotation = newRotation
-                            val newOffset = controlPadItem.offset + offsetChange.rotateBy(newRotation) * newScale
+                            
+                            val snappedNewRotation = snappedRotation(newRotation)
+
+                            val newOffset = controlPadItem.offset + offsetChange.rotateBy(
+                                if (rotationChange == 0f) controlPadItem.rotation
+                                else if (_uiState.value.useAngleSnap) snappedNewRotation
+                                else newRotation
+                            ) * newScale
 
                             uiState.value.controlPadItems[index] =
                                 controlPadItem.copy(
                                     offsetX = newOffset.x,
                                     offsetY = newOffset.y,
                                     // Joystick and steering wheel should not be rotatable
-                                    rotation = if(controlPadItem.itemType == ItemType.JOYSTICK || controlPadItem.itemType == ItemType.STEERING_WHEEL) 0f
-                                    else if (_uiState.value.useAngleSnap) snappedRotation(newRotation) else newRotation,
+                                    rotation = if (rotationChange == 0f) controlPadItem.rotation
+                                            else if (_uiState.value.useAngleSnap) snappedNewRotation
+                                            else newRotation,
                                     scale = newScale.coerceIn(minScale,maxScale)
                                 )
 
@@ -228,17 +240,29 @@ class ControlPadBuilderScreenViewModel @Inject constructor(
                                     val controlPadItem = uiState.value.controlPadItems[index]
 
                                     val newScale = controlPadItem.scale * zoomChange
-                                    val newRotation = temporalRotation + rotationChange
+
+                                    val newRotation = if(controlPadItem.itemType == ItemType.JOYSTICK || controlPadItem.itemType == ItemType.STEERING_WHEEL) 0f
+                                    else if (_uiState.value.useAngleSnap){ temporalRotation + rotationChange }
+                                    else{ controlPadItem.rotation + rotationChange }
+
                                     temporalRotation = newRotation
-                                    val newOffset = controlPadItem.offset + offsetChange.rotateBy(newRotation) * newScale
+
+                                    val snappedNewRotation = snappedRotation(newRotation)
+
+                                    val newOffset = controlPadItem.offset + offsetChange.rotateBy(
+                                        if (rotationChange == 0f) controlPadItem.rotation
+                                        else if (_uiState.value.useAngleSnap) snappedNewRotation
+                                        else newRotation
+                                    ) * newScale
 
                                     uiState.value.controlPadItems[index] =
                                         controlPadItem.copy(
                                             offsetX = newOffset.x,
                                             offsetY = newOffset.y,
                                             // Joystick and steering wheel should not be rotatable
-                                            rotation = if(controlPadItem.itemType == ItemType.JOYSTICK || controlPadItem.itemType == ItemType.STEERING_WHEEL) 0f
-                                                    else if (_uiState.value.useAngleSnap) snappedRotation(newRotation) else newRotation,
+                                            rotation = if (rotationChange == 0f) controlPadItem.rotation
+                                            else if (_uiState.value.useAngleSnap) snappedNewRotation
+                                            else newRotation,
                                             scale = newScale.coerceIn(minScale,maxScale)
                                         )
 

--- a/app/src/test/java/com/github/umer0586/droidpad/MigrationTest.kt
+++ b/app/src/test/java/com/github/umer0586/droidpad/MigrationTest.kt
@@ -14,7 +14,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import kotlin.jvm.Throws
 
 @RunWith(RobolectricTestRunner::class)
 class MigrationTest {

--- a/app/src/test/java/com/github/umer0586/droidpad/connectiontests/WebsocketConnectionTest.kt
+++ b/app/src/test/java/com/github/umer0586/droidpad/connectiontests/WebsocketConnectionTest.kt
@@ -3,8 +3,8 @@ package com.github.umer0586.droidpad.connectiontests
 import app.cash.turbine.test
 import com.github.umer0586.droidpad.MainDispatcherRule
 import com.github.umer0586.droidpad.data.connection.ConnectionState
-import com.github.umer0586.droidpad.data.connectionconfig.WebsocketConfig
 import com.github.umer0586.droidpad.data.connection.WebsocketConnection
+import com.github.umer0586.droidpad.data.connectionconfig.WebsocketConfig
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -17,7 +17,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.lang.Exception
 import java.net.InetSocketAddress
 
 @Ignore("This Tests times out with 'gradlew test' but works fine when run manually")

--- a/app/src/test/java/com/github/umer0586/droidpad/daotests/ConnectionConfigDaoTest.kt
+++ b/app/src/test/java/com/github/umer0586/droidpad/daotests/ConnectionConfigDaoTest.kt
@@ -2,8 +2,8 @@ package com.github.umer0586.droidpad.daotests
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import com.github.umer0586.droidpad.data.database.AppDatabase
 import com.github.umer0586.droidpad.MainDispatcherRule
+import com.github.umer0586.droidpad.data.database.AppDatabase
 import com.github.umer0586.droidpad.data.database.dao.ConnectionConfigurationDao
 import com.github.umer0586.droidpad.data.database.dao.ControlPadDao
 import com.github.umer0586.droidpad.data.database.entities.ConnectionConfig

--- a/app/src/test/java/com/github/umer0586/droidpad/daotests/ControlPadDaoTest.kt
+++ b/app/src/test/java/com/github/umer0586/droidpad/daotests/ControlPadDaoTest.kt
@@ -2,8 +2,8 @@ package com.github.umer0586.droidpad.daotests
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import com.github.umer0586.droidpad.data.database.AppDatabase
 import com.github.umer0586.droidpad.MainDispatcherRule
+import com.github.umer0586.droidpad.data.database.AppDatabase
 import com.github.umer0586.droidpad.data.database.dao.ControlPadDao
 import com.github.umer0586.droidpad.data.database.dao.ControlPadItemDao
 import com.github.umer0586.droidpad.data.database.entities.ControlPad

--- a/app/src/test/java/com/github/umer0586/droidpad/daotests/ControlPadItemDaoTest.kt
+++ b/app/src/test/java/com/github/umer0586/droidpad/daotests/ControlPadItemDaoTest.kt
@@ -2,15 +2,14 @@ package com.github.umer0586.droidpad.daotests
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import com.github.umer0586.droidpad.data.database.AppDatabase
 import com.github.umer0586.droidpad.MainDispatcherRule
+import com.github.umer0586.droidpad.data.database.AppDatabase
 import com.github.umer0586.droidpad.data.database.dao.ControlPadDao
 import com.github.umer0586.droidpad.data.database.dao.ControlPadItemDao
 import com.github.umer0586.droidpad.data.database.entities.ControlPad
 import com.github.umer0586.droidpad.data.database.entities.ControlPadItem
 import com.github.umer0586.droidpad.data.database.entities.ItemType
 import com.github.umer0586.droidpad.data.database.entities.Orientation
-
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/github/umer0586/droidpad/repositorytests/ControlPadRepositoryImpTest.kt
+++ b/app/src/test/java/com/github/umer0586/droidpad/repositorytests/ControlPadRepositoryImpTest.kt
@@ -2,8 +2,8 @@ package com.github.umer0586.droidpad.repositorytests
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
-import com.github.umer0586.droidpad.data.database.AppDatabase
 import com.github.umer0586.droidpad.MainDispatcherRule
+import com.github.umer0586.droidpad.data.database.AppDatabase
 import com.github.umer0586.droidpad.data.database.entities.ControlPad
 import com.github.umer0586.droidpad.data.database.entities.ControlPadItem
 import com.github.umer0586.droidpad.data.database.entities.ItemType

--- a/app/src/test/java/com/github/umer0586/droidpad/uitests/ItemEditorTest.kt
+++ b/app/src/test/java/com/github/umer0586/droidpad/uitests/ItemEditorTest.kt
@@ -7,11 +7,11 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
-import com.github.umer0586.droidpad.data.database.entities.ControlPadItem
-import com.github.umer0586.droidpad.data.database.entities.ItemType
 import com.github.umer0586.droidpad.data.ButtonProperties
 import com.github.umer0586.droidpad.data.LabelProperties
 import com.github.umer0586.droidpad.data.SliderProperties
+import com.github.umer0586.droidpad.data.database.entities.ControlPadItem
+import com.github.umer0586.droidpad.data.database.entities.ItemType
 import com.github.umer0586.droidpad.ui.components.propertieseditor.ItemPropertiesEditorSheet
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail


### PR DESCRIPTION
I just think it'll be very nice if control pad items are able to snap to specific angles or other item.
Thinking it won‘t be very hard, I wrote this today.

Added a button in the center of the bottom bar with a menu,
![1764242122879](https://github.com/user-attachments/assets/2445f5fb-b990-438d-acaa-d00a8a0440d0)
![1764242122889](https://github.com/user-attachments/assets/4e4baef7-1818-4eea-8dc2-d1fd20a65bd4)

It mainly functions well, but sometimes seems buggy interacting. I think maybe the modifier _transformable_'s absent perception of the end of a gesture have made it need modifications to update the rotation completely as expected. I'm sure my programming skill is below the average(be honest, learned a lot from your work making this.) and to be less invasive, I kept the base as is.

https://github.com/user-attachments/assets/75dfcd7b-830a-4b40-8305-a0d95914e003

I have little time for this, but I'll keep track once I have.

By the way, thank you very much for mentioning my simple glue mod.